### PR TITLE
Clean up Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,20 +1,17 @@
 SHELL   = sh
 CXX     = g++
-#CFLAGS = -g -std=gnu++11 $(INCLUDE)
-#CFLAGS = -g -std=gnu++11 -D_GLIBCXX_DEBUG $(INCLUDE)
-#CFLAGS = -O3 -DNDEBUG $(INCLUDE)
-CFLAGS = -O3 -DNDEBUG -std=gnu++11 $(INCLUDE)
+#CXXFLAGS = -g -std=gnu++11 $(INCLUDE)
+#CXXFLAGS = -g -std=gnu++11 -D_GLIBCXX_DEBUG $(INCLUDE)
+#CXXFLAGS = -O3 -DNDEBUG $(INCLUDE)
+CXXFLAGS = -O3 -DNDEBUG -std=gnu++11 $(INCLUDE)
 
-LDFLAGS = -llapack
+LDFLAGS = -L$(LAPACK_DIR) -llapack
 OBJ2 = scat3.o utility.o mt19937ar.o readboundary.o
 
-SCAT3 : $(OBJ2) scat3.hpp utility.hpp readboundary.hpp
+SCAT3 : $(OBJ2)
 	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-.SUFFIXES: .cpp .o
-
-.cpp.o:
-	$(CXX) $(CFLAGS) -c $<
+.SUFFIXES: .hpp .cpp .o
 
 TAGS: *.hpp *.cpp
 	etags $^

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ CXX     = g++
 #CXXFLAGS = -O3 -DNDEBUG $(INCLUDE)
 CXXFLAGS = -O3 -DNDEBUG -std=gnu++11 $(INCLUDE)
 
-LDFLAGS = -L$(LAPACK_DIR) -llapack
+LDFLAGS = -llapack
 OBJ2 = scat3.o utility.o mt19937ar.o readboundary.o
 
 SCAT3 : $(OBJ2)

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ CXX     = g++
 #CXXFLAGS = -g -std=gnu++11 $(INCLUDE)
 #CXXFLAGS = -g -std=gnu++11 -D_GLIBCXX_DEBUG $(INCLUDE)
 CFLAGS = -O3 -DNDEBUG $(INCLUDE)
-CXXFLAGS = -O3 -DNDEBUG -std=gnu++11 $(INCLUDE)
+CXXFLAGS = $(CFLAGS) -std=gnu++11
 
 LDFLAGS = -llapack
 OBJ2 = scat3.o utility.o mt19937ar.o readboundary.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,16 +2,16 @@ SHELL   = sh
 CXX     = g++
 #CXXFLAGS = -g -std=gnu++11 $(INCLUDE)
 #CXXFLAGS = -g -std=gnu++11 -D_GLIBCXX_DEBUG $(INCLUDE)
-#CXXFLAGS = -O3 -DNDEBUG $(INCLUDE)
+CFLAGS = -O3 -DNDEBUG $(INCLUDE)
 CXXFLAGS = -O3 -DNDEBUG -std=gnu++11 $(INCLUDE)
 
 LDFLAGS = -llapack
 OBJ2 = scat3.o utility.o mt19937ar.o readboundary.o
 
+.SUFFIXES: .hpp .cpp .o
+
 SCAT3 : $(OBJ2)
 	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)
-
-.SUFFIXES: .hpp .cpp .o
 
 TAGS: *.hpp *.cpp
 	etags $^
@@ -28,3 +28,9 @@ clean:
 
 ultraclean: clean
 	rm -f SCAT3
+
+mt19937ar.o: mt19937ar.hpp
+readboundary.o: readboundary.hpp
+utility.o: utility.hpp
+scat3.o: scat3.hpp mt19937ar.hpp readboundary.hpp
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,7 @@ clean:
 ultraclean: clean
 	rm -f SCAT3
 
-mt19937ar.o: mt19937ar.hpp
+mt19937ar.o: mt19937ar.h
 readboundary.o: readboundary.hpp
 utility.o: utility.hpp
 scat3.o: scat3.hpp mt19937ar.hpp readboundary.hpp

--- a/src/Makefile_intel
+++ b/src/Makefile_intel
@@ -8,7 +8,7 @@ CFLAGS = -O3 -xHost -DNDEBUG $(INCLUDE)
 CXXFLAGS = $(CFLAGS) -std=c++11
 
 # MKL rather than plain LAPACK
-LDFLAGS = -L$(MKLROOT)/lib/intel64 -lmkl_rt -lpthread -lm -ldl
+LDFLAGS = -L$(MKLROOT)/lib/intel64 -Wl,-rpath,$(MKLROOT)/lib/intel64 -lmkl_rt -lpthread -lm -ldl
 OBJ2 = scat3.o utility.o mt19937ar.o readboundary.o
 
 .SUFFIXES: .hpp .cpp .o

--- a/src/Makefile_intel
+++ b/src/Makefile_intel
@@ -1,0 +1,39 @@
+SHELL   = sh
+CXX     = icpc
+CC      = icc
+#CXXFLAGS = -g -std=gnu++11 $(INCLUDE)
+#CXXFLAGS = -g -std=gnu++11 -D_GLIBCXX_DEBUG $(INCLUDE)
+INCLUDE = -I$(MKLROOT)/include
+CFLAGS = -O3 -xHost -DNDEBUG $(INCLUDE)
+CXXFLAGS = $(CFLAGS) -std=c++11
+
+# MKL rather than plain LAPACK
+LDFLAGS = -L$(MKLROOT)/lib/intel64 -lmkl_rt -lpthread -lm -ldl
+OBJ2 = scat3.o utility.o mt19937ar.o readboundary.o
+
+.SUFFIXES: .hpp .cpp .o
+
+SCAT3 : $(OBJ2)
+	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+TAGS: *.hpp *.cpp
+	etags $^
+
+tags: *.hpp *.cpp
+	ctags $^
+
+# Stripping off the symbols can make the executable smaller.
+strip: SCAT3
+	strip $^
+
+clean:
+	rm -rf *.o *.out
+
+ultraclean: clean
+	rm -f SCAT3
+
+mt19937ar.o: mt19937ar.h
+readboundary.o: readboundary.hpp
+utility.o: utility.hpp
+scat3.o: scat3.hpp mt19937ar.hpp readboundary.hpp
+


### PR DESCRIPTION
* `.cpp.o` suffix rule not necessary if use `CXXFLAGS` instead of `CFLAGS`. The rules is defined by default (see [GNU Make documentation](https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html#Catalogue-of-Rules)).
* Add `.hpp` to the `SUFFIXES` list
* Modify `CFLAGS` to remove `-std=g++11` since that is C++-only
* Add individual rules for `.hpp` and `.h` (for `mt19937ar.o`) rather than putting `.hpp` files in the link line of `SCAT3`. (Header files are included, not compiled.)